### PR TITLE
Update folder names in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,10 @@ bootfiles/boot.*
 bootfiles/boot.*/*
 bootfiles/grub_switch_hashes/*
 
-usb_device/build/**
+2_usb_device/build/**
 
-usb_device/*.hex
-usb_device/*.map
-usb_device/*.elf
+2_usb_device/*.hex
+2_usb_device/*.map
+2_usb_device/*.elf
 
 


### PR DESCRIPTION
The folder structure was renamed in commit [203f653](https://github.com/rw-hsma-fpga/grub-switch/commit/203f65334cd321f293a5adac7ef8a7abfd5620b4) but the gitignore was not updated. Because of this the microcontroller build results are not ignored.